### PR TITLE
Resolve package.json merge issue to use peer dependency for tern 

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "tern": "^0.17.0"
   },    
   "dependencies": {
-    "tern": "^0.17.0",
     "eslint": "^4.0.0"
   },
   "devDependencies": { 


### PR DESCRIPTION
Hi @angelozerr ,

Thanks for looking at those request so quickly!

Looks like there was an issue while merging #20 that cause tern to be duplicated as both a `peerDependencies` and `dependencies`  - if test are passing with this pull request, can we merge the changes and tag 0.6?